### PR TITLE
up haproxy to 1.7.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# haproxy1.7.8 with certbot fork from https://github.com/nmarus/docker-haproxy-certbot
+# haproxy1.7.8 with certbot 
 FROM debian:jessie-backports
 
 RUN apt-get update \


### PR DESCRIPTION
copy Dockerfile source from https://github.com/docker-library/haproxy/blob/9b5d5bf547d296049a8e8a22ac951e1b76f3179c/1.7/Dockerfile